### PR TITLE
テーマボタンの共通化

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,4 +1,6 @@
 <footer>
     <p>© 2025 Taishi Nishino <br />
         本サイトのデータは <a href="opendata.html">札幌市オープンデータ</a> を基にしています。</p>
+    <!-- テーマ切り替えボタンを共通で配置 -->
+    <button id="themeToggle" aria-label="テーマ切り替え">🌓</button>
 </footer>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,5 @@
             .then(response => response.text())
             .then(data => document.getElementById('footer').innerHTML = data);
     </script>
-    <!-- テーマ切り替えボタンをページ共通で表示 -->
-    <button id="themeToggle" aria-label="テーマ切り替え">🌓</button>
 </body>
 </html>

--- a/opendata.html
+++ b/opendata.html
@@ -21,8 +21,6 @@
         <br>
         <button onclick="window.history.back()">← 戻る</button>
     </div>
-    <!-- テーマ切り替えボタンをページ共通で表示 -->
-    <button id="themeToggle" aria-label="テーマ切り替え">🌓</button>
     <script src="theme.js"></script>
 </body>
 </html>

--- a/theme.js
+++ b/theme.js
@@ -5,12 +5,19 @@ if (prefersDark) {
 }
 
 // ボタンが読み込まれてからイベントを設定
+// ボタンの存在を監視してイベントを登録
 document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('themeToggle');
-    if (btn) {
-        btn.addEventListener('click', () => {
-            const enabled = document.body.classList.toggle('dark');
-            localStorage.setItem('theme', enabled ? 'dark' : 'light');
-        });
+    function attachToggle() {
+        const btn = document.getElementById('themeToggle');
+        if (btn && !btn.dataset.listenerAdded) {
+            btn.addEventListener('click', () => {
+                const enabled = document.body.classList.toggle('dark');
+                localStorage.setItem('theme', enabled ? 'dark' : 'light');
+            });
+            btn.dataset.listenerAdded = 'true';
+        }
     }
+
+    attachToggle();
+    new MutationObserver(attachToggle).observe(document.body, { childList: true, subtree: true });
 });

--- a/timetable.html
+++ b/timetable.html
@@ -67,7 +67,5 @@
             .then(response => response.text())
             .then(data => document.getElementById('footer').innerHTML = data);
     </script>
-    <!-- テーマ切り替えボタンをページ共通で表示 -->
-    <button id="themeToggle" aria-label="テーマ切り替え">🌓</button>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- フッター内にテーマ切り替えボタンを追加して全ページから利用可能に
- 各HTMLから重複していたボタンを削除
- 動的にボタンが読み込まれる場合にも対応するよう`theme.js`を更新

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686458616f1c832c9fa56c2a8348eb12