### PR TITLE
SVGアイコンを使ったテーマ切り替え

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -2,5 +2,5 @@
     <p>© 2025 Taishi Nishino <br />
         本サイトのデータは <a href="opendata.html">札幌市オープンデータ</a> を基にしています。</p>
     <!-- テーマ切り替えボタンを共通で配置 -->
-    <button id="themeToggle" aria-label="テーマ切り替え">🌓</button>
+    <button id="themeToggle" aria-label="テーマ切り替え"></button>
 </footer>

--- a/theme.js
+++ b/theme.js
@@ -1,19 +1,28 @@
-// テーマ設定を初期化
+// ページ読込時に保存されたテーマを適用
 const prefersDark = localStorage.getItem('theme') === 'dark';
 if (prefersDark) {
     document.body.classList.add('dark');
 }
 
-// ボタンが読み込まれてからイベントを設定
-// ボタンの存在を監視してイベントを登録
+// フッターのボタンにイベントを登録
 document.addEventListener('DOMContentLoaded', () => {
     function attachToggle() {
         const btn = document.getElementById('themeToggle');
         if (btn && !btn.dataset.listenerAdded) {
+            const svgMoon = '<svg viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 0111.21 3 7 7 0 1012 21a9 9 0 009-8.21z"></path></svg>';
+            const svgSun  = '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="5"></circle><path d="M12 1v2m0 18v2m11-11h-2M3 12H1m16.95 6.95l-1.41-1.41M5.46 5.46L4.05 4.05m12.9 0l-1.41 1.41M5.46 18.54l-1.41 1.41"></path></svg>';
+
+            function updateIcon() {
+                btn.innerHTML = document.body.classList.contains('dark') ? svgSun : svgMoon;
+            }
+
             btn.addEventListener('click', () => {
                 const enabled = document.body.classList.toggle('dark');
                 localStorage.setItem('theme', enabled ? 'dark' : 'light');
+                updateIcon();
             });
+
+            updateIcon();
             btn.dataset.listenerAdded = 'true';
         }
     }


### PR DESCRIPTION
## Summary
- フッターのテーマ切り替えボタンから絵文字を除去
- `theme.js` でSVGアイコンを用いてボタンの表示を更新

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864fd346d28832c824d04b02e81935b