### PR TITLE
Add sliding side menu with theme toggle

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,6 +1,4 @@
 <footer>
     <p>© 2025 Taishi Nishino <br />
         本サイトのデータは <a href="opendata.html">札幌市オープンデータ</a> を基にしています。</p>
-    <!-- テーマ切り替えボタンを共通で配置 -->
-    <button id="themeToggle" aria-label="テーマ切り替え"></button>
 </footer>

--- a/index.html
+++ b/index.html
@@ -7,8 +7,16 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div id="app">
+    <header>
         <h1>東豊線 時刻表</h1>
+        <button id="menuBtn" aria-label="メニュー">≡</button>
+    </header>
+    <nav id="sideMenu" role="dialog" aria-label="メニュー">
+        <button id="themeToggle">テーマ切り替え</button>
+        <ul></ul>
+    </nav>
+    <div id="overlay"></div>
+    <div id="app">
         <div id="currentTime"></div>
 
         <div id="stationSelect">
@@ -35,6 +43,7 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
     <script src="script.js"></script>
     <script src="theme.js"></script>
+    <script src="menu.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('sw.js');

--- a/menu.js
+++ b/menu.js
@@ -1,0 +1,59 @@
+// メニュー開閉とフォーカストラップ
+ document.addEventListener('DOMContentLoaded', () => {
+     const menuBtn = document.getElementById('menuBtn');
+     const sideMenu = document.getElementById('sideMenu');
+     const overlay = document.getElementById('overlay');
+
+     let firstFocus;
+     let lastFocus;
+
+     function setFocusables() {
+         const focusables = sideMenu.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+         firstFocus = focusables[0];
+         lastFocus = focusables[focusables.length - 1];
+     }
+
+     function openMenu() {
+         document.body.classList.add('menu-open');
+         setFocusables();
+         firstFocus && firstFocus.focus();
+         sideMenu.addEventListener('keydown', trapFocus);
+     }
+
+     function closeMenu() {
+         document.body.classList.remove('menu-open');
+         sideMenu.removeEventListener('keydown', trapFocus);
+         menuBtn.focus();
+     }
+
+     function trapFocus(e) {
+         if (e.key !== 'Tab') return;
+         if (e.shiftKey && document.activeElement === firstFocus) {
+             e.preventDefault();
+             lastFocus.focus();
+         } else if (!e.shiftKey && document.activeElement === lastFocus) {
+             e.preventDefault();
+             firstFocus.focus();
+         }
+     }
+
+     menuBtn.addEventListener('click', () => {
+         if (document.body.classList.contains('menu-open')) {
+             closeMenu();
+         } else {
+             openMenu();
+         }
+     });
+
+     overlay.addEventListener('click', closeMenu);
+
+     document.addEventListener('keydown', (e) => {
+         if (e.key === 'Escape' && document.body.classList.contains('menu-open')) {
+             closeMenu();
+         }
+     });
+
+     if (window.attachThemeToggle) {
+         window.attachThemeToggle();
+     }
+ });

--- a/styles.css
+++ b/styles.css
@@ -21,6 +21,25 @@ h1 {
     font-size: 1.6em;
 }
 
+header {
+    position: relative;
+    background: #007BFF;
+    color: #fff;
+    text-align: center;
+    padding: 10px 0;
+}
+
+#menuBtn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 1.5em;
+    cursor: pointer;
+    color: inherit;
+}
+
 #currentTime {
     font-size: 2em;
     font-weight: bold;
@@ -242,22 +261,51 @@ body.dark .search-btn:hover {
     background-color: #555;
 }
 
-#themeToggle {
-    /* 画面右下に固定 */
+
+#sideMenu {
     position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-size: 1.2em;
+    right: -260px;
+    top: 0;
+    width: 260px;
+    height: 100%;
+    background: #fff;
+    transition: right .3s;
     z-index: 1000;
+    padding: 20px;
+    box-sizing: border-box;
 }
 
-#themeToggle:hover {
-    opacity: 0.8;
+.menu-open #sideMenu {
+    right: 0;
 }
 
-body.dark #themeToggle {
-    color: #fff;
+#overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .3s;
+    z-index: 999;
+}
+
+.menu-open #overlay {
+    opacity: .5;
+    pointer-events: auto;
+}
+
+body.dark #sideMenu {
+    background: #1e1e1e;
+}
+
+body.dark #overlay {
+    background: #000;
+}
+
+#themeToggle {
+    position: static;
+    margin-bottom: 10px;
 }

--- a/tests/e2e/theme_toggle.cy.js
+++ b/tests/e2e/theme_toggle.cy.js
@@ -1,0 +1,12 @@
+// ハンバーガーメニューとテーマ切り替えの E2E テスト
+ describe('menu and theme', () => {
+     it('opens menu and toggles theme', () => {
+         cy.visit('index.html');
+         cy.get('#menuBtn').click();
+         cy.get('#sideMenu').should('be.visible');
+         cy.get('#themeToggle').click();
+         cy.get('body').should('have.class', 'dark');
+         cy.get('#overlay').click();
+         cy.get('#sideMenu').should('not.be.visible');
+     });
+ });

--- a/theme.js
+++ b/theme.js
@@ -27,6 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    window.attachThemeToggle = attachToggle;
+
     attachToggle();
     new MutationObserver(attachToggle).observe(document.body, { childList: true, subtree: true });
 });

--- a/timetable.html
+++ b/timetable.html
@@ -7,8 +7,16 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div id="app">
+    <header>
         <h1>時刻表一覧</h1>
+        <button id="menuBtn" aria-label="メニュー">≡</button>
+    </header>
+    <nav id="sideMenu" role="dialog" aria-label="メニュー">
+        <button id="themeToggle">テーマ切り替え</button>
+        <ul></ul>
+    </nav>
+    <div id="overlay"></div>
+    <div id="app">
 
         <!-- 駅・方面・曜日の選択（修正版） -->
         <div id="stationSelect">
@@ -55,6 +63,7 @@
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
     <script src="timetable.js"></script>
     <script src="theme.js"></script>
+    <script src="menu.js"></script>
     <script>
         if ('serviceWorker' in navigator) {
             navigator.serviceWorker.register('sw.js');


### PR DESCRIPTION
## Summary
- add shared header with hamburger menu
- implement sliding side menu and overlay
- move theme toggle button into menu
- style header and menu elements
- expose `attachThemeToggle` and new `menu.js`
- add Cypress sample test

## Testing
- `npm test`
- `npx cypress run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686500ee9f80832cbe642e1a28573c79