### PR TITLE
時刻表ソートとダークテーマ調整

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,6 +55,8 @@ async function displayTimetable() {
             const [hour, min] = row.発車時刻.split(':');
             return { time: row.発車時刻, minutes: parseInt(hour) * 60 + parseInt(min) };
         })
+        // 発車時刻を昇順に並べ替える
+        .sort((a, b) => a.minutes - b.minutes)
         .filter(entry => entry.minutes >= currentTime)
         .slice(0, 3);
 

--- a/styles.css
+++ b/styles.css
@@ -58,8 +58,9 @@ select {
     font-size: 1em;
 }
 
-button {
-    width: 80%; /* スマホで見やすいサイズに調整 */
+/* サイドメニューボタンを除く */
+button:not(#menuBtn) {
+    width: 80%;
     padding: 12px;
     background-color: #28a745;
     color: white;
@@ -70,7 +71,8 @@ button {
     transition: background 0.3s ease;
 }
 
-button:hover {
+/* サイドメニューボタンを除く */
+button:not(#menuBtn):hover {
     background-color: #218838;
 }
 
@@ -128,20 +130,6 @@ button.disabled {
     gap: 10px;
     margin: 20px auto;
     max-width: 400px;
-}
-
-.hour-tile {
-    background: #007BFF;
-    color: white;
-    padding: 10px;
-    border-radius: 5px;
-    border: none;
-    cursor: pointer;
-    text-align: center;
-}
-
-.hour-tile:hover {
-    background: #0056b3;
 }
 
 /* モーダルスタイル */
@@ -244,7 +232,8 @@ body.dark .modal-content {
     background: #272727;
 }
 
-body.dark button,
+/* ダークテーマ時のボタン (menuBtn除外) */
+body.dark button:not(#menuBtn),
 body.dark .btn,
 body.dark .back-btn,
 body.dark .hour-tile,
@@ -253,12 +242,23 @@ body.dark .search-btn {
     color: #fff;
 }
 
-body.dark button:hover,
+/* ダークテーマ時のホバー (menuBtn除外) */
+body.dark button:not(#menuBtn):hover,
 body.dark .btn:hover,
 body.dark .back-btn:hover,
 body.dark .hour-tile:hover,
 body.dark .search-btn:hover {
     background-color: #555;
+}
+
+/* ダークテーマのヘッダー色 */
+body.dark header {
+    background-color: #1e1e1e;
+}
+
+/* ダークテーマのリンク色 */
+body.dark a {
+    color: #80b3ff;
 }
 
 

--- a/timetable.js
+++ b/timetable.js
@@ -81,18 +81,25 @@ async function displayFullTimetable() {
         if (row.曜日 === dayType && row.方向 === direction && row.駅名 === stationName) {
             let [hour, min] = row.発車時刻.split(':');
             hour = parseInt(hour, 10);
-            if (hour === 0) hour = 24;
             if (!groupedByHour[hour]) groupedByHour[hour] = [];
             groupedByHour[hour].push(min);
         }
     });
 
+    // 各時間帯の分を昇順に並べ替える
+    Object.keys(groupedByHour).forEach(hour => {
+        groupedByHour[hour].sort((a, b) => parseInt(a) - parseInt(b));
+    });
+
     const hourGrid = document.getElementById('hourGrid');
-    hourGrid.innerHTML = Object.keys(groupedByHour)
-        .map(Number).sort((a, b) => a - b)
+    // 0時を24時として扱い、最後に並べる
+    const sortedHours = Object.keys(groupedByHour)
+        .map(Number)
+        .sort((a, b) => (a === 0 ? 24 : a) - (b === 0 ? 24 : b));
+    hourGrid.innerHTML = sortedHours
         .map(hour => `
-            <button class="hour-tile" onclick="openModal('${hour % 24}', '${groupedByHour[hour].join(', ')}')">
-                ${hour % 24}時
+            <button class="hour-tile" onclick="openModal('${hour}', '${groupedByHour[hour].join(', ')}')">
+                ${hour}時
             </button>
         `).join('');
 }
@@ -140,13 +147,24 @@ async function searchNearestTrains() {
         .slice(0, 3);
 
     const searchResults = document.getElementById('searchResults');
+    // 結果表示エリアを初期化
+    searchResults.innerHTML = '';
+
     if (nearestTrains.length > 0) {
-        searchResults.innerHTML = `<h3>近い電車</h3>
-            <ul>
-                ${nearestTrains.map(train => `<li>${train.time}（あと ${train.totalMinutes - searchMinutes} 分）</li>`).join('')}
-            </ul>`;
+        const heading = document.createElement('h3');
+        heading.textContent = '近い電車';
+        const list = document.createElement('ul');
+        nearestTrains.forEach(train => {
+            const li = document.createElement('li');
+            li.textContent = `${train.time}（あと ${train.totalMinutes - searchMinutes} 分）`;
+            list.appendChild(li);
+        });
+        searchResults.appendChild(heading);
+        searchResults.appendChild(list);
     } else {
-        searchResults.innerHTML = `<p>該当する電車がありません</p>`;
+        const message = document.createElement('p');
+        message.textContent = '該当する電車がありません';
+        searchResults.appendChild(message);
     }
 }
 


### PR DESCRIPTION
## 概要
- 0時を末尾に並べて時刻表を正しい順序で表示
- ハンバーガーアイコンが消える問題を修正

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897e99c5f7c832cb4a9825f8f9b8f9a